### PR TITLE
https://bugs.telegram.org/c/939: hide chat mention if private group

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Adapters/MentionsAdapter.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Adapters/MentionsAdapter.java
@@ -726,7 +726,7 @@ public class MentionsAdapter extends RecyclerListView.SelectionAdapter {
                     TLObject object;
                     int id;
                     if (a == -1) {
-                        if (chat == null) {
+                        if (TextUtils.isEmpty(chat.username)) {
                             continue;
                         }
                         if (usernameString.length() == 0) {


### PR DESCRIPTION
https://bugs.telegram.org/c/939

**Steps to reproduce**
Go to any private group
Type @ + Name Of The Group
Press on the group name from the list
**Current result**
Press on the group name does nothing.

**Expected result**
The group name should not be in the list.


Video before:
https://user-images.githubusercontent.com/3606758/106387565-63eef080-63eb-11eb-91c1-76590d073e85.mp4
Video fixed: 
https://user-images.githubusercontent.com/3606758/106387587-6f421c00-63eb-11eb-81be-be52f24232ee.mp4





