### PR TITLE
https://bugs.telegram.org/c/676: add check layout after measure for p…

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -2897,7 +2897,7 @@ public class MessageObject {
     }
 
     public boolean checkLayout() {
-        if (type != 0 || messageOwner.peer_id == null || messageText == null || messageText.length() == 0) {
+        if ((type != 0 && type != TYPE_POLL) || messageOwner.peer_id == null || messageText == null || messageText.length() == 0) {
             return false;
         }
         if (layoutCreated) {


### PR DESCRIPTION
https://bugs.telegram.org/c/676 Visual issue with polls

Steps to reproduce
Go to any chat to find a poll
Rotate your screen to landscape mode
Go to the profile of the chat
Rotate your screen to portrait mode
Return to the chat
Current result
The poll exceeds the screen size

Expected result
The poll should be displayed correctly

Video before:
https://user-images.githubusercontent.com/3606758/107125209-8e442080-68b9-11eb-8b30-28f5cf0bde0a.mp4
Video fixed:
https://user-images.githubusercontent.com/3606758/107125217-9d2ad300-68b9-11eb-9558-b391e77565ce.mp4

