### PR TITLE
https://bugs.telegram.org/c/792: Incorrect order for tracks across several playlists

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -2163,13 +2163,12 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
                 if (group1 != 0 && group1 == group2) {
                     return Integer.compare(mid1, mid2);
                 }
-                return Integer.compare(mid2, mid1);
             } else {
                 if (group1 != 0 && group1 == group2) {
                     return Integer.compare(mid2, mid1);
                 }
-                return Integer.compare(mid1, mid2);
             }
+            return Long.compare(group2, group1);
         });
     }
 


### PR DESCRIPTION
https://bugs.telegram.org/c/792

The files are uploaded in the correct order (1-9) across 3 playlists (1-3, 4-6, 7-9). The player displays them incorrectly. (shuffle is not enabled.)

Group for testing orders
https://t.me/test_tracks_order

Steps to reproduce
Upload two or more music playlists to a chat.
Play the first track of the first playlist.
Current result
The music player will not play them in the correct order, kindly see screenshots attached.

Expected result
The player should display and play the music in the correct order, even if they're in more than one playlist

**Before**
![before](https://user-images.githubusercontent.com/3606758/107886235-a1856a80-6f0f-11eb-86e2-c684b70251f7.jpg)
https://user-images.githubusercontent.com/3606758/107886258-bd890c00-6f0f-11eb-85ac-624a25b1c934.mp4

**After**
![after](https://user-images.githubusercontent.com/3606758/107886251-b2ce7700-6f0f-11eb-9ad6-2f3b9062441f.jpg)
https://user-images.githubusercontent.com/3606758/107886259-c974ce00-6f0f-11eb-9a64-a57297c47faf.mp4


